### PR TITLE
feat(k8s): add Reloader auto annotation to backend deployment

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
     app: backend
     component: api
+  annotations:
+    reloader.stakater.com/auto: "true"
 spec:
   replicas: 2
   revisionHistoryLimit: 2


### PR DESCRIPTION
## Summary
Add `reloader.stakater.com/auto: "true"` annotation to the backend deployment so it auto-restarts when `backend-secrets.ELASTICSEARCH_PASSWORD` updates.

Pairs with [fovi-longa-chat-be#27](https://github.com/Data-Longa/fovi-longa-chat-be/pull/27) which installed Reloader and the ESO password mirror.

## Test plan
- [ ] After merge: `kubectl get deploy -n chatbu backend -o jsonpath='{.metadata.annotations.reloader\.stakater\.com/auto}'` returns `true`
- [ ] Test rotation: change `elasticsearch-master-credentials/password` → ESO mirrors to `backend-secrets` (~30s) → Reloader auto-restarts the backend pods

🤖 Generated with [Claude Code](https://claude.com/claude-code)