### PR TITLE
feat(security): rate limit + booking-verification module

### DIFF
--- a/prisma/migrations/20260501020000_add_booking_verification/migration.sql
+++ b/prisma/migrations/20260501020000_add_booking_verification/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "BookingVerification" (
+    "id" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "code" TEXT NOT NULL,
+    "botCuid" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "used" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "BookingVerification_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "BookingVerification_email_botCuid_idx" ON "BookingVerification"("email", "botCuid");
+
+-- CreateIndex
+CREATE INDEX "BookingVerification_expiresAt_idx" ON "BookingVerification"("expiresAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -490,3 +490,16 @@ model SystemLog {
   @@index([createdAt])
   @@index([status])
 }
+
+model BookingVerification {
+  id        String   @id @default(cuid())
+  email     String
+  code      String   // 6-digit OTP, plaintext (matches existing User.activationCode pattern; row is short-lived and single-use)
+  botCuid   String
+  expiresAt DateTime
+  used      Boolean  @default(false)
+  createdAt DateTime @default(now())
+
+  @@index([email, botCuid])
+  @@index([expiresAt])
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { APP_GUARD } from '@nestjs/core';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { ConfigModule } from '@nestjs/config';
@@ -6,6 +7,7 @@ import { AuthenticationModule } from './authentication/authentication.module';
 import { WinstonModule } from 'nest-winston';
 import * as winston from 'winston';
 import { CacheModule } from '@nestjs/cache-manager';
+import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
 import { MailModule } from './mail/mail.module';
 import { FileModule } from './file/file.module';
 import { MinioClientModule } from './minio-client/minio-client.module';
@@ -31,6 +33,15 @@ import { WhatsAppModule } from './whatsapp/whatsapp.module';
   imports: [
     ScheduleModule.forRoot(),
     CacheModule.register({ isGlobal: true }),
+    // Global rate limit. THROTTLE_TTL is milliseconds in env (existing convention from
+    // chatbu-secrets) but @nestjs/throttler v6 expects ms too — pass through directly.
+    // Defaults: 100 requests per 60 seconds per IP.
+    ThrottlerModule.forRoot([
+      {
+        ttl: parseInt(process.env.THROTTLE_TTL || '60000', 10),
+        limit: parseInt(process.env.THROTTLE_LIMIT || '100', 10),
+      },
+    ]),
     WinstonModule.forRoot({
       format: winston.format.combine(
         winston.format.timestamp(),
@@ -45,6 +56,12 @@ import { WhatsAppModule } from './whatsapp/whatsapp.module';
       isGlobal: true,
     }), AuthenticationModule, MailModule, FileModule, MinioClientModule, PrismaModule, BotModule, QuotaModule, ReportModule, EventsModule, ContentModule, AdminModule, TeamModule, SubscriptionModule, FeedbackModule, TicketModule, IntegrationModule, SystemLogModule, MetaModule, WhatsAppModule],
   controllers: [AppController],
-  providers: [AppService],
+  providers: [
+    AppService,
+    {
+      provide: APP_GUARD,
+      useClass: ThrottlerGuard,
+    },
+  ],
 })
 export class AppModule { }

--- a/src/integration/booking/booking.controller.ts
+++ b/src/integration/booking/booking.controller.ts
@@ -1,0 +1,99 @@
+import {
+    Body,
+    Controller,
+    HttpCode,
+    HttpException,
+    HttpStatus,
+    Post,
+    UseGuards,
+} from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Throttle } from '@nestjs/throttler';
+import { InternalApiKeyGuard } from '../google-calendar/internal-api-key.guard';
+import { BookingService } from './booking.service';
+
+class RequestVerificationDto {
+    email!: string;
+    botCuid!: string;
+}
+
+class VerifyDto {
+    email!: string;
+    code!: string;
+    botCuid!: string;
+}
+
+class CheckTokenDto {
+    token!: string;
+    email!: string;
+    botCuid!: string;
+}
+
+@ApiTags('Booking Verification (internal)')
+@Controller('integration/booking')
+@UseGuards(InternalApiKeyGuard)
+export class BookingController {
+    constructor(private readonly booking: BookingService) { }
+
+    /**
+     * POST /api/integration/booking/request-verification
+     * mcp-server calls this when the agent wants to send a verification email.
+     */
+    @ApiOperation({ summary: 'Send a 6-digit verification code to the user (internal)' })
+    @ApiResponse({ status: 200, description: 'Code sent' })
+    @ApiResponse({ status: 429, description: 'Too many requests for this email' })
+    @Throttle({ default: { ttl: 3600000, limit: 20 } }) // 20/hour at the controller level (per-email cap is in the service)
+    @Post('request-verification')
+    @HttpCode(200)
+    async request(@Body() body: RequestVerificationDto) {
+        if (!body.email || !body.botCuid) {
+            throw new HttpException('email and botCuid are required', HttpStatus.BAD_REQUEST);
+        }
+        try {
+            return await this.booking.requestVerification(body.email, body.botCuid);
+        } catch (e) {
+            if ((e as Error).message === 'TOO_MANY_REQUESTS') {
+                throw new HttpException('Too many code requests; try again later', HttpStatus.TOO_MANY_REQUESTS);
+            }
+            throw e;
+        }
+    }
+
+    /**
+     * POST /api/integration/booking/verify
+     * mcp-server calls this when the user provided a code in chat.
+     * Returns a short-lived JWT used by create_appointment.
+     */
+    @ApiOperation({ summary: 'Verify a code and issue a booking token (internal)' })
+    @ApiResponse({ status: 200, description: 'Verification result returned' })
+    @Post('verify')
+    @HttpCode(200)
+    async verify(@Body() body: VerifyDto) {
+        if (!body.email || !body.code || !body.botCuid) {
+            throw new HttpException('email, code, and botCuid are required', HttpStatus.BAD_REQUEST);
+        }
+        return this.booking.verify(body.email, body.code, body.botCuid);
+    }
+
+    /**
+     * POST /api/integration/booking/check-token
+     * mcp-server's create_appointment calls this before creating the calendar event.
+     * Returns 200 if token is valid + matches the email/botCuid; throws otherwise.
+     */
+    @ApiOperation({ summary: 'Validate a booking verification JWT (internal)' })
+    @ApiResponse({ status: 200, description: 'Token is valid' })
+    @ApiResponse({ status: 401, description: 'Token invalid, expired, or mismatched' })
+    @Post('check-token')
+    @HttpCode(200)
+    async checkToken(@Body() body: CheckTokenDto) {
+        if (!body.token || !body.email || !body.botCuid) {
+            throw new HttpException('token, email, and botCuid are required', HttpStatus.BAD_REQUEST);
+        }
+        try {
+            await this.booking.checkToken(body.token, body.email, body.botCuid);
+            return { valid: true };
+        } catch (e) {
+            throw new HttpException('Invalid or expired booking token', HttpStatus.UNAUTHORIZED);
+        }
+    }
+}

--- a/src/integration/booking/booking.module.ts
+++ b/src/integration/booking/booking.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { JwtModule } from '@nestjs/jwt';
+import { PrismaModule } from 'src/prisma/prisma.module';
+import { MailModule } from 'src/mail/mail.module';
+import { BookingController } from './booking.controller';
+import { BookingService } from './booking.service';
+
+@Module({
+    imports: [PrismaModule, MailModule, JwtModule.register({})],
+    controllers: [BookingController],
+    providers: [BookingService],
+})
+export class BookingModule { }

--- a/src/integration/booking/booking.service.ts
+++ b/src/integration/booking/booking.service.ts
@@ -1,0 +1,111 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { MailService } from 'src/mail/mail.service';
+
+const CODE_TTL_MINUTES = 10;
+const VERIFICATION_TOKEN_TTL_SECONDS = 5 * 60;
+const MAX_CODE_REQUESTS_PER_HOUR = 5;
+
+@Injectable()
+export class BookingService {
+    private readonly logger = new Logger(BookingService.name);
+
+    constructor(
+        private readonly prisma: PrismaService,
+        private readonly mail: MailService,
+        private readonly jwt: JwtService,
+    ) { }
+
+    /**
+     * Generate a 6-digit code, persist it, and email the user.
+     * Throws if the email has already requested too many codes this hour.
+     */
+    async requestVerification(email: string, botCuid: string) {
+        const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
+        const recentCount = await this.prisma.bookingVerification.count({
+            where: { email, botCuid, createdAt: { gte: oneHourAgo } },
+        });
+        if (recentCount >= MAX_CODE_REQUESTS_PER_HOUR) {
+            this.logger.warn(`Too many verification requests for ${email} on bot ${botCuid}`);
+            throw new Error('TOO_MANY_REQUESTS');
+        }
+
+        const code = Math.floor(100000 + Math.random() * 900000).toString();
+        const expiresAt = new Date(Date.now() + CODE_TTL_MINUTES * 60 * 1000);
+
+        const record = await this.prisma.bookingVerification.create({
+            data: { email, botCuid, code, expiresAt },
+        });
+
+        // Look up bot display name for the email subject/body. Fail soft if not found.
+        let botName = 'our team';
+        try {
+            const bot = await this.prisma.customerBots.findUnique({
+                where: { id: botCuid },
+                select: { botName: true },
+            });
+            if (bot?.botName) botName = bot.botName;
+        } catch (e) {
+            this.logger.warn(`Could not look up bot name for ${botCuid}: ${e}`);
+        }
+
+        await this.mail.sendBookingVerificationMail(email, code, botName);
+
+        return {
+            verificationId: record.id,
+            expiresInSeconds: CODE_TTL_MINUTES * 60,
+        };
+    }
+
+    /**
+     * Validate a code. Marks the matching record `used=true` so it can't be replayed.
+     * Returns a short-lived signed JWT that mcp-server passes to create_appointment.
+     */
+    async verify(email: string, code: string, botCuid: string) {
+        const record = await this.prisma.bookingVerification.findFirst({
+            where: {
+                email,
+                code,
+                botCuid,
+                used: false,
+                expiresAt: { gt: new Date() },
+            },
+            orderBy: { createdAt: 'desc' },
+        });
+
+        if (!record) {
+            return { verified: false as const };
+        }
+
+        await this.prisma.bookingVerification.update({
+            where: { id: record.id },
+            data: { used: true },
+        });
+
+        const verificationToken = await this.jwt.signAsync(
+            { email, botCuid, sub: record.id },
+            {
+                secret: process.env.BOOKING_VERIFICATION_SECRET || process.env.JWT_SECRET,
+                expiresIn: VERIFICATION_TOKEN_TTL_SECONDS,
+            },
+        );
+
+        return { verified: true as const, verificationToken };
+    }
+
+    /**
+     * Verify a JWT issued by `verify()`. Returns the payload if valid, throws if not.
+     * mcp-server's create_appointment calls this before creating the calendar event.
+     */
+    async checkToken(token: string, email: string, botCuid: string) {
+        const payload = await this.jwt.verifyAsync<{ email: string; botCuid: string; sub: string }>(
+            token,
+            { secret: process.env.BOOKING_VERIFICATION_SECRET || process.env.JWT_SECRET },
+        );
+        if (payload.email !== email || payload.botCuid !== botCuid) {
+            throw new Error('TOKEN_MISMATCH');
+        }
+        return payload;
+    }
+}

--- a/src/integration/integration.module.ts
+++ b/src/integration/integration.module.ts
@@ -4,9 +4,10 @@ import { IntegrationService } from './integration.service';
 import { GoogleCalendarController } from './google-calendar/google-calendar.controller';
 import { GoogleCalendarService } from './google-calendar/google-calendar.service';
 import { PrismaModule } from 'src/prisma/prisma.module';
+import { BookingModule } from './booking/booking.module';
 
 @Module({
-    imports: [PrismaModule],
+    imports: [PrismaModule, BookingModule],
     controllers: [IntegrationController, GoogleCalendarController],
     providers: [IntegrationService, GoogleCalendarService],
 })

--- a/src/mail/mail.service.ts
+++ b/src/mail/mail.service.ts
@@ -174,6 +174,44 @@ export class MailService {
     }
   }
 
+  async sendBookingVerificationMail(
+    email: string,
+    code: string,
+    botName: string,
+  ) {
+    const rootDir = process.cwd();
+
+    const templatePath = path.join(
+      rootDir,
+      'dist',
+      'templates',
+      'booking-verification.html',
+    );
+    const templateSource = fs.readFileSync(templatePath, 'utf8');
+    const template = handlebars.compile(templateSource);
+    const html = template({
+      code,
+      botName: botName || 'our team',
+      privacy_policy_url: process.env.FRONTEND_PRIVACY_POLICY_URL,
+      support_url: process.env.FRONTEND_SUPPORT_URL,
+    });
+
+    const mailOptions = {
+      from: process.env.ADMIN_EMAIL,
+      to: email,
+      subject: `Verify your appointment with ${botName || 'our team'}`,
+      html,
+    };
+
+    try {
+      await this.mailerService.sendMail(mailOptions);
+      this.logger.info(`Booking verification mail sent to ${email}`);
+    } catch (error) {
+      console.error(error);
+      throw error;
+    }
+  }
+
   async sendEmailVerificationMail(
     email: string,
     code: string,

--- a/src/mail/templates/booking-verification.html
+++ b/src/mail/templates/booking-verification.html
@@ -1,0 +1,102 @@
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Verify your appointment</title>
+    <style>
+      body {
+        font-family: Arial, Helvetica, sans-serif;
+        line-height: 1.6;
+        color: #333333;
+        margin: 0;
+        padding: 0;
+        background-color: #f7f7f7;
+      }
+      p {
+        font-size: 16px;
+      }
+      .container {
+        max-width: 600px;
+        margin: 0 auto;
+        padding: 20px;
+        background-color: #ffffff;
+      }
+      .header {
+        text-align: center;
+        padding: 20px 0;
+        border-bottom: 1px solid #eeeeee;
+      }
+      .logo {
+        max-height: 60px;
+        margin-bottom: 10px;
+      }
+      .content {
+        padding: 30px 20px;
+        text-align: center;
+      }
+      .verification-code {
+        font-size: 32px;
+        font-weight: bold;
+        letter-spacing: 5px;
+        margin: 30px 0;
+        color: #2b72e4;
+        padding: 15px;
+        background-color: #f0f5ff;
+        border-radius: 8px;
+        display: inline-block;
+      }
+      .footer {
+        text-align: center;
+        padding: 20px;
+        color: #999999;
+        font-size: 12px;
+        border-top: 1px solid #eeeeee;
+      }
+      .note {
+        font-size: 14px;
+        color: #777777;
+        margin-top: 25px;
+      }
+      @media only screen and (max-width: 600px) {
+        .container {
+          width: 100%;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <div class="header">
+        <img
+          src="https://chatbu.io/wp-content/uploads/2025/03/Group-1-2.png"
+          alt="Chatbu Logo"
+          class="logo"
+        />
+        <h2>Verify your appointment with {{botName}}</h2>
+      </div>
+
+      <div class="content">
+        <p>Hello,</p>
+
+        <p>Use the code below to confirm your appointment request:</p>
+
+        <div class="verification-code">{{code}}</div>
+
+        <p>This code is valid for 10 minutes. Return to the chat and enter it to complete your booking.</p>
+
+        <p class="note">
+          If you didn't request this appointment, you can safely ignore this email.
+        </p>
+      </div>
+
+      <div class="footer">
+        <p>&copy; 2026 Chatbu. All rights reserved.</p>
+        <p>
+          <a href="{{privacy_policy_url}}">Privacy Policy</a>
+          |
+          <a href="{{support_url}}">Support</a>
+        </p>
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
Two related anti-abuse changes on the NestJS side, on one branch.

### Commit 1: wire @nestjs/throttler globally (Phase 1)
- `@nestjs/throttler` v6 was already in `package.json` but never registered.
- Now wired in `AppModule` with a global `APP_GUARD` using existing `THROTTLE_TTL` (60000ms) / `THROTTLE_LIMIT` (100) env vars.
- Default policy: 100 requests per 60 seconds per IP, applied to every controller.

### Commit 2: booking-verification module (Phase 2)
Identity proof per appointment booking — the user must confirm a 6-digit code sent to the email they provided in chat. mcp-server calls these endpoints in the booking flow.

- New Prisma model `BookingVerification` + migration (email, code, botCuid, expiresAt, used, createdAt).
- New module `src/integration/booking/`:
  - `POST /api/integration/booking/request-verification` — generates 6-digit code, persists, emails the user. Soft per-email cap of 5/hour.
  - `POST /api/integration/booking/verify` — validates code, marks used, issues a 5-min JWT signed with `BOOKING_VERIFICATION_SECRET` (or `JWT_SECRET` fallback).
  - `POST /api/integration/booking/check-token` — verifies the JWT before `create_appointment` runs.
  - All three guarded by `InternalApiKeyGuard`.
- `MailService.sendBookingVerificationMail()` — new method, vertical-agnostic copy.
- New Handlebars template `src/mail/templates/booking-verification.html` — bot display name parameterized so the email reads naturally for any tenant (clinic, salon, gym, lawyer, etc.).

Pairs with fovi-longa-chat-be Phase 1 ([#33](https://github.com/Data-Longa/fovi-longa-chat-be/pull/33)) and the upcoming fovi-longa-chat-be Phase 2 (mcp-server tool + prompt update).

## Required env (set in chatbu-secrets before merging)
- `BOOKING_VERIFICATION_SECRET` — JWT signing secret. Falls back to `JWT_SECRET` if unset, but prefer dedicated.

## Test plan
- [ ] After deploy: burst >100 requests/minute from one IP to any endpoint → 429
- [ ] Run migration: `BookingVerification` table exists in Postgres
- [ ] `curl -X POST /api/integration/booking/request-verification` with valid `X-Internal-Key` → email arrives, code persisted
- [ ] Same flow without `X-Internal-Key` → 401
- [ ] Same email requesting >5 codes/hour → 429
- [ ] Verify with correct code → returns JWT; verify with wrong code → `{verified: false}`
- [ ] check-token with valid JWT → 200; expired JWT → 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)