### PR TITLE
fix(billing): DB-level dedup for ingestion token tracking

### DIFF
--- a/prisma/migrations/20260501160000_dedup_token_usage_log/migration.sql
+++ b/prisma/migrations/20260501160000_dedup_token_usage_log/migration.sql
@@ -1,0 +1,18 @@
+-- Remove existing duplicate rows for ingestion-style operations before adding
+-- the unique constraint. Keep the EARLIEST row per (taskId, operationType).
+-- Note: this does NOT correct already-double-counted Subscription.tokensUsedThisMonth.
+DELETE FROM "TokenUsageLog" t1
+USING "TokenUsageLog" t2
+WHERE t1."taskId" IS NOT NULL
+  AND t1."taskId" = t2."taskId"
+  AND t1."operationType" = t2."operationType"
+  AND (
+    t1."createdAt" > t2."createdAt"
+    OR (t1."createdAt" = t2."createdAt" AND t1."id" > t2."id")
+  );
+
+-- CreateIndex
+-- Partial behavior is implicit: Postgres treats NULL values as distinct in
+-- unique indexes, so chat rows (taskId IS NULL) remain unconstrained.
+CREATE UNIQUE INDEX "TokenUsageLog_taskId_operationType_key"
+ON "TokenUsageLog"("taskId", "operationType");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -358,6 +358,10 @@ model TokenUsageLog {
   createdAt      DateTime     @default(now())
   subscription   Subscription @relation(fields: [subscriptionId], references: [id], onDelete: Cascade)
 
+  // DB-level dedup for ingestion (and any future taskId-scoped operations).
+  // Postgres treats NULL as distinct in unique indexes, so chat rows
+  // (taskId=NULL) are not affected — multiple NULL-taskId rows are allowed.
+  @@unique([taskId, operationType], name: "TokenUsageLog_taskId_operationType_key")
   @@index([operationType])
   @@index([teamId])
   @@index([createdAt])

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -17,9 +17,6 @@ export class EventsService implements OnModuleInit {
         connectionString: process.env.DATABASE_URL,
     });
 
-    // Prevent duplicate token tracking for the same ingestion task
-    private trackedTaskIds = new Set<string>();
-
 
     async onModuleInit() {
         console.log('EventsService initializing...');
@@ -55,15 +52,18 @@ export class EventsService implements OnModuleInit {
                 console.log('Received notification on ingestion_task_updates:', payload);
                 await this.eventGateWay.notifyUser(payload.customer_cuid, tempPayload);
 
-                // Track ingestion tokens when task completes (deduplicate by task_id)
-                if (payload.status === 'completed' && payload.tokens_consumed > 0 && !this.trackedTaskIds.has(payload.task_id)) {
-                    this.trackedTaskIds.add(payload.task_id);
+                // Track ingestion tokens when the task completes. Dedup is enforced
+                // at the DB level via TokenUsageLog's unique (taskId, operationType)
+                // index — both backend pods receive every NOTIFY (LISTEN broadcasts),
+                // and only one INSERT will succeed. The other gets P2002 and exits
+                // silently inside trackTokenUsage.
+                if (payload.status === 'completed' && payload.tokens_consumed > 0) {
                     try {
                         const team = await this.prisma.team.findUnique({
                             where: { id: payload.customer_cuid },
                         });
                         if (team) {
-                            await this.subscriptionService.trackTokenUsage(
+                            const result = await this.subscriptionService.trackTokenUsage(
                                 team.ownerId,
                                 payload.tokens_consumed,
                                 payload.customer_cuid,
@@ -72,11 +72,12 @@ export class EventsService implements OnModuleInit {
                                 'ingestion',
                                 payload.task_id,
                             );
-                            console.log(`Tracked ${payload.tokens_consumed} ingestion tokens for team ${payload.customer_cuid}`);
+                            if (result.success) {
+                                console.log(`Tracked ${payload.tokens_consumed} ingestion tokens for team ${payload.customer_cuid} (task ${payload.task_id})`);
+                            }
                         }
                     } catch (e) {
                         console.error('Failed to track ingestion tokens:', e);
-                        this.trackedTaskIds.delete(payload.task_id);
                     }
                 }
             }

--- a/src/subscription/subscription.service.ts
+++ b/src/subscription/subscription.service.ts
@@ -582,53 +582,76 @@ export class SubscriptionService {
             throw new NotFoundException('Subscription not found');
         }
 
-        // Update tokens used
-        await this.prisma.subscription.update({
-            where: { userId },
-            data: {
-                tokensUsedThisMonth: subscription.tokensUsedThisMonth + tokensUsed,
-            },
-        });
-
-        // Calculate cost for overage (if PREMIUM and exceeded base allocation)
+        // Pre-compute cost so the log row carries it. Stripe reporting + spending-limit
+        // enforcement happen AFTER tracking so they don't leave the system in a state
+        // where tokens were charged but never recorded (the previous version of this
+        // function had that bug).
         let cost = 0;
         const baseAllocation = subscription.monthlyTokenAllocation;
-
+        let overageTokens = 0;
         if (subscription.tier === 'PREMIUM' && subscription.tokensUsedThisMonth >= baseAllocation) {
-            // Only charge for tokens beyond the base allocation
-            const overageTokens = Math.min(tokensUsed, subscription.tokensUsedThisMonth + tokensUsed - baseAllocation);
+            overageTokens = Math.min(tokensUsed, subscription.tokensUsedThisMonth + tokensUsed - baseAllocation);
             if (overageTokens > 0) {
                 const tokenPrice = await this.getTokenPrice();
                 cost = (overageTokens / 1000) * tokenPrice;
-
-                // Check spending limit
-                if (subscription.spendingLimit) {
-                    const currentMonthCost = await this.getCurrentMonthCost(userId);
-                    if (currentMonthCost + cost > subscription.spendingLimit) {
-                        throw new BadRequestException('Spending limit exceeded. Please increase your limit or wait for the next billing cycle.');
-                    }
-                }
-
-                // Report usage to Stripe if there's overage and spending limit is set
-                if (subscription.spendingLimit && subscription.stripeSubscriptionId) {
-                    await this.reportUsageToStripe(subscription.stripeSubscriptionId, subscription.stripeCustomerId, overageTokens, cost);
-                }
             }
         }
 
-        // Log token usage
-        await this.prisma.tokenUsageLog.create({
-            data: {
-                subscriptionId: subscription.id,
-                teamId,
-                botId,
-                chatId,
-                taskId,
-                operationType,
-                tokensUsed,
-                cost,
-            },
-        });
+        // Atomic insert + counter increment. The TokenUsageLog has a unique index on
+        // (taskId, operationType) — Postgres treats NULL as distinct so chat rows
+        // (taskId=null) are unaffected, but ingestion duplicates from a second backend
+        // pod hit P2002. On dup, the transaction rolls back and the subscription
+        // counter is NOT incremented a second time.
+        try {
+            await this.prisma.$transaction(async (tx) => {
+                await tx.tokenUsageLog.create({
+                    data: {
+                        subscriptionId: subscription.id,
+                        teamId,
+                        botId,
+                        chatId,
+                        taskId,
+                        operationType,
+                        tokensUsed,
+                        cost,
+                    },
+                });
+                await tx.subscription.update({
+                    where: { userId },
+                    data: {
+                        tokensUsedThisMonth: { increment: tokensUsed },
+                    },
+                });
+            });
+        } catch (e: any) {
+            if (e?.code === 'P2002' && taskId) {
+                // Another replica already tracked this task. Silent skip — do not
+                // increment counters, do not report to Stripe.
+                console.log(`[trackTokenUsage] duplicate skipped taskId=${taskId} operationType=${operationType}`);
+                return {
+                    success: false,
+                    duplicate: true,
+                    tokensUsed: 0,
+                    cost: 0,
+                    tokensRemaining: subscription.monthlyTokenAllocation + subscription.additionalTokensPurchased - subscription.tokensUsedThisMonth,
+                };
+            }
+            throw e;
+        }
+
+        // Spending-limit check + Stripe report run after the row is committed.
+        if (overageTokens > 0 && cost > 0) {
+            if (subscription.spendingLimit) {
+                const currentMonthCost = await this.getCurrentMonthCost(userId);
+                if (currentMonthCost + cost > subscription.spendingLimit) {
+                    throw new BadRequestException('Spending limit exceeded. Please increase your limit or wait for the next billing cycle.');
+                }
+            }
+
+            if (subscription.spendingLimit && subscription.stripeSubscriptionId) {
+                await this.reportUsageToStripe(subscription.stripeSubscriptionId, subscription.stripeCustomerId, overageTokens, cost);
+            }
+        }
 
         return {
             success: true,


### PR DESCRIPTION
## Summary
Backend dev reported ingestion tokens counted multiple times per completion. Root cause: the dedup at [events.service.ts:21](src/events/events.service.ts#L21) was an in-memory `Set<string>` per pod. Backend runs with multiple replicas and Postgres `LISTEN/NOTIFY` broadcasts to every connection, so each pod's dedup ran independently and both called `trackTokenUsage` with the same `task_id`.

## Fix
- **Schema**: `@@unique([taskId, operationType])` on `TokenUsageLog`. Postgres treats `NULL` as distinct in unique indexes, so chat rows (`taskId=null`) are unaffected — only `(non-null taskId, operationType)` pairs are constrained.
- **Migration**: deletes pre-existing duplicate rows (keeping the earliest per pair) before creating the unique index.
- **`trackTokenUsage`**: wraps the `TokenUsageLog.create` + `Subscription.update` in a single `$transaction`. On Prisma P2002 the whole thing rolls back — no double increment, no Stripe report. Uses `{increment: tokensUsed}` instead of snapshot+add for safer concurrency.
- **Side-effect ordering fix (drive-by)**: spending-limit check + Stripe report now run AFTER the tracking row is committed. The previous version threw `BadRequestException` between subscription update and log insert, leaving tokens charged but never logged.
- **`EventsService`**: drops the in-memory `trackedTaskIds` Set — DB enforces dedup now.

## Tokens already double-counted
This PR stops the bleeding going forward. It does NOT correct `Subscription.tokensUsedThisMonth` for past duplicates. If you want a one-off compensation migration, say so and I'll add it separately.

## Test plan
- [ ] After deploy: trigger an ingestion → exactly one `TokenUsageLog` row appears with that `taskId` and `operationType=ingestion`
- [ ] `Subscription.tokensUsedThisMonth` increments by exactly `tokens_consumed`, not 2× or 3×
- [ ] Backend pod logs show `[trackTokenUsage] duplicate skipped` from the loser of the race
- [ ] Chat token tracking still works (multiple log rows with `taskId=NULL` allowed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)