### PR TITLE
fix(calendar): restore full calendar scope so freebusy.query works

### DIFF
--- a/src/integration/google-calendar/google-calendar.service.ts
+++ b/src/integration/google-calendar/google-calendar.service.ts
@@ -9,7 +9,10 @@ import { PrismaService } from 'src/prisma/prisma.service';
 import { SystemLogService } from 'src/system-log/system-log.service';
 
 const INTEGRATION_TYPE = 'google-calendar';
-const SCOPES = ['https://www.googleapis.com/auth/calendar.events'];
+// Full `calendar` scope is required so check_availability can call freebusy.query —
+// `calendar.events` alone returns 403 insufficientPermissions on freebusy. Narrowing
+// this scope was a drive-by change in 64b977c that broke every booking flow.
+const SCOPES = ['https://www.googleapis.com/auth/calendar'];
 const EXPIRY_BUFFER_MS = 5 * 60 * 1000; // 5 minutes
 
 @Injectable()


### PR DESCRIPTION
## Summary
- Booking has been broken on the public chat agent since **2026-04-24**: every `check_availability` call returns `403 insufficientPermissions` from Google, the mcp-server surfaces `CALENDAR_SERVICE_UNAVAILABLE`, and the agent falls back to "contact the team directly".
- Root cause: commit `64b977c` (whose message is "feat: implement create user functionality for Admin with validation DTO") quietly narrowed the OAuth scope from `https://www.googleapis.com/auth/calendar` to `https://www.googleapis.com/auth/calendar.events`. The narrow scope permits creating events on accessible calendars but does not grant read access — `freebusy.query` rejects it.
- Fix: revert to the full `calendar` scope. (Practically equivalent to `calendar.events + calendar.readonly` since `readonly` already grants read of every calendar, but one scope is simpler on the consent screen and on any future Google OAuth verification.)

## Post-deploy step (important)
Existing tokens were issued under the narrow scope and **cannot be upgraded** without a fresh consent. Every already-connected bot must reconnect Google Calendar in the dashboard after this ships to receive a token under the wider scope.

## Test plan
- [ ] Deploy to a test bot, reconnect Google Calendar from the dashboard
- [ ] In the public chat widget, ask for an appointment for a future slot
- [ ] Confirm the agent calls `check_availability` and returns `FREE`/`BUSY` instead of falling back
- [ ] Complete a booking through the OTP verification flow and confirm a Google Calendar invite arrives at the attendee's email
- [ ] Notify all production bot owners that a one-time Google Calendar reconnect is required

🤖 Generated with [Claude Code](https://claude.com/claude-code)