### PR TITLE
refactor(k8s): decouple intra-cluster URLs to bare service names

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -37,15 +37,15 @@ spec:
         - name: PORT
           value: "3001"
         - name: API_URL
-          value: "http://backend.chatbu.svc.cluster.local:3001"
+          value: "http://backend:3001"
         - name: FRONTEND_URL
           value: "https://app.chatbu.io"
         - name: CORS_ORIGIN
           value: "https://app.chatbu.io,https://chatbu.io"
         - name: INGEST_ENPOINT
-          value: "http://fastapi-gateway-service.chatbu.svc.cluster.local:8000"
+          value: "http://fastapi-gateway-service:8000"
         - name: MCP_API_GATEWAY_URL
-          value: "http://fastapi-gateway-service.chatbu.svc.cluster.local:8000"
+          value: "http://fastapi-gateway-service:8000"
         resources:
           requests:
             memory: "1Gi"


### PR DESCRIPTION
Companion to Data-Longa/fovi-longa-chat-be#77 — the backend half of the
intra-cluster DNS decoupling.

`API_URL` / `INGEST_ENPOINT` / `MCP_API_GATEWAY_URL` go from
`<svc>.chatbu.svc.cluster.local` FQDNs to namespace-relative bare service
names. Behaviour-preserving in `chatbu` (a bare name resolves to the same
Service for a pod in that namespace); unblocks a co-tenanted `chatbu-dev`.

Scoped to `k8s/deployment.yaml` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)