### PR TITLE
feat(dev): chatbu-dev overlay + develop-branch CI

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -2,7 +2,7 @@ name: Backend CI/CD
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
     paths-ignore:
       - 'README.md'
       - 'docs/**'
@@ -44,6 +44,14 @@ jobs:
           TIMESTAMP=$(date +%Y%m%d%H%M%S)
           SHORT_SHA=${GITHUB_SHA::7}
           
+          # develop → backend-dev (chatbu-dev); main → backend-latest (chatbu).
+          if [ "${GITHUB_REF}" = "refs/heads/develop" ]; then
+            echo "channel=backend-dev" >> $GITHUB_OUTPUT
+            echo "namespace=chatbu-dev" >> $GITHUB_OUTPUT
+          else
+            echo "channel=backend-latest" >> $GITHUB_OUTPUT
+            echo "namespace=chatbu" >> $GITHUB_OUTPUT
+          fi
           echo "version=backend-${SHORT_SHA}" >> $GITHUB_OUTPUT
           echo "timestamp=backend-${TIMESTAMP}" >> $GITHUB_OUTPUT
           echo "latest=backend-latest" >> $GITHUB_OUTPUT
@@ -55,7 +63,7 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: |
-            ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ steps.meta.outputs.latest }}
+            ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ steps.meta.outputs.channel }}
             ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ steps.meta.outputs.version }}
             ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ steps.meta.outputs.timestamp }}
           cache-from: type=gha
@@ -67,8 +75,8 @@ jobs:
       - name: Restart backend deployment on EKS
         run: |
           aws eks update-kubeconfig --name chatbu-prod --region ${{ env.AWS_REGION }}
-          kubectl rollout restart deployment/backend -n chatbu
-          kubectl rollout status deployment/backend -n chatbu --timeout=300s
+          kubectl rollout restart deployment/backend -n ${{ steps.meta.outputs.namespace }}
+          kubectl rollout status deployment/backend -n ${{ steps.meta.outputs.namespace }} --timeout=300s
 
       - name: Deployment summary
         run: |

--- a/k8s-dev/kustomization.yaml
+++ b/k8s-dev/kustomization.yaml
@@ -1,0 +1,35 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# chatbu-dev overlay for the NestJS backend. Lives OUTSIDE k8s/ so the prod
+# backend Application (source path `k8s`, using k8s/kustomization.yaml) is
+# completely untouched. References the prod base kustomization root `../k8s`
+# and adds a dev-local backend RBAC copy. The `namespace:` transformer
+# rewrites every metadata.namespace and the RoleBinding subject namespace.
+namespace: chatbu-dev
+
+resources:
+  - ../k8s          # prod base root (deployment + service + hpa)
+  - rbac.yaml       # dev-local SA/Role/RoleBinding (not in the base)
+
+images:
+  - name: 152100380489.dkr.ecr.eu-central-1.amazonaws.com/chatbu-repo
+    newTag: backend-dev
+
+patches:
+  # 1 replica + dev public URLs
+  - path: patch-backend.yaml
+    target:
+      kind: Deployment
+      name: backend
+
+  # delete HPA (single-pod dev)
+  - target:
+      kind: HorizontalPodAutoscaler
+      name: backend
+    patch: |-
+      apiVersion: autoscaling/v2
+      kind: HorizontalPodAutoscaler
+      metadata:
+        name: backend
+      $patch: delete

--- a/k8s-dev/patch-backend.yaml
+++ b/k8s-dev/patch-backend.yaml
@@ -1,0 +1,18 @@
+# Strategic-merge: env is a list keyed by `name`, so these two entries
+# override just FRONTEND_URL / CORS_ORIGIN; all other env vars (already
+# namespace-relative bare names from the Step 1 edit) are inherited.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+        - name: backend
+          env:
+            - name: FRONTEND_URL
+              value: "https://dev.chatbu.io"
+            - name: CORS_ORIGIN
+              value: "https://dev.chatbu.io"

--- a/k8s-dev/rbac.yaml
+++ b/k8s-dev/rbac.yaml
@@ -1,0 +1,36 @@
+# backend RBAC for the dev namespace. The prod base kustomization (k8s/) does
+# NOT include rbac-backend-k8s.yaml, so it cannot be pulled in as a base
+# resource; this is a small dev-local copy (namespace is injected by the
+# overlay's namespace transformer → chatbu-dev). backend pods run as
+# serviceAccountName: backend-sa and would fail to start without it.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: backend-sa
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: backend-ops-role
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: backend-ops-binding
+subjects:
+  - kind: ServiceAccount
+    name: backend-sa
+roleRef:
+  kind: Role
+  name: backend-ops-role
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Backend half of the co-tenanted `chatbu-dev` environment
(see Data-Longa/fovi-longa-chat-be#78).

- **k8s-dev/**: Kustomize overlay placed *outside* `k8s/` so the prod
  `k8s` ArgoCD path is 100% untouched. Sets namespace `chatbu-dev`,
  `replicas=1`, drops the HPA, adds dev-local backend RBAC, pins the
  `backend-dev` image.
- **ci-cd.yml**: `develop` pushes build `backend-dev` and roll
  `deployment/backend -n chatbu-dev`; `main` unchanged (`backend-latest`
  -> `chatbu`).

Depends on #16 (intra-cluster DNS decoupling) being on the branch the dev
app tracks. The `chatbu-backend-dev` ArgoCD Application (in the fovi PR)
points at this repo's `develop` branch, path `k8s-dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)