### PR TITLE
fix(dev): stop Karpenter draining the dev backend pod every 15-20min

### DIFF
--- a/k8s-dev/patch-backend.yaml
+++ b/k8s-dev/patch-backend.yaml
@@ -16,6 +16,16 @@ metadata:
 spec:
   replicas: 1
   template:
+    metadata:
+      annotations:
+        # Stop Karpenter from draining the dev backend during consolidation.
+        # chatbu-dev pods land on the shared spot node group and have no PDB
+        # (single-replica dev), so Karpenter was free to evict them every
+        # 15-20 minutes, producing intermittent 503s at the ingress while
+        # the backend Service had no available endpoint. `do-not-disrupt`
+        # disables Karpenter consolidation for the pod. Spot interruption
+        # from AWS is unaffected (less frequent, unavoidable).
+        karpenter.sh/do-not-disrupt: "true"
     spec:
       containers:
         - name: backend


### PR DESCRIPTION
## Why

chatbu-dev pods land on the shared spot node group and have **no PDB** (single-replica dev — overlay explicitly deletes the prod PDB). That left Karpenter free to evict the backend pod on every consolidation pass — observed **~3x/hour** in karpenter logs, with chatbu-dev/backend-* pods appearing in \`found provisionable pod(s)\` events after every drain. While the pod recreates, the backend Service has no endpoint and the ingress returns 503 (or API requests hang for a few seconds).

Surfaced today as "from time to time I see 503" on the dev frontend.

## Fix

\`karpenter.sh/do-not-disrupt: \"true\"\` annotation on the dev backend pod template via the existing strategic-merge patch (\`k8s-dev/patch-backend.yaml\`).

Karpenter respects this for **consolidation** drains; the pod stays put.

**Spot interruption** (\`messageKind: spot_interrupted\`) is unaffected — AWS-driven, unavoidable without moving to on-demand. Less frequent than consolidation, so user-visible 503 rate should drop significantly.

## Companion PRs

- **chatbu-frontend#32** — same annotation on the dev frontend pod (shipping in parallel)
- **Data-Longa/fovi-longa-chat-be** dev internal services (fastapi-gateway, ml-services, mcp-server, redis) — next batch

## Test plan

- Merge → ArgoCD chatbu-backend-dev syncs → kustomize re-renders deployment with the new annotation → pod rolls once
- Verify annotation:
  \`\`\`bash
  kubectl -n chatbu-dev get pod -l app=backend \    -o jsonpath='{.items[0].metadata.annotations.karpenter\\.sh/do-not-disrupt}'
  \`\`\`
- Pod AGE should monotonically increase (no Karpenter-driven kills)
- Karpenter logs should NOT mention \`chatbu-dev/backend-*\` in \`provisionable pod(s)\` events anymore (only on spot interruption)

🤖 Generated with [Claude Code](https://claude.com/claude-code)