### PR TITLE
fix(prod): stop Karpenter evicting prod backend during consolidation

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -19,6 +19,15 @@ spec:
       labels:
         app: backend
         component: api
+      annotations:
+        # Karpenter consolidation was evicting prod backend pods during
+        # cluster-wide rebalancing — observed 2026-06-12 prod outage when
+        # all stateless pods were drained at once, the cluster ended up
+        # with zero Karpenter nodes, CoreDNS couldn't schedule, EC2 API
+        # DNS resolution broke for Karpenter, and a chicken-and-egg
+        # deadlock kept the cluster down ~20min. Voluntary disruption
+        # off; spot interruption (AWS-driven) is unaffected.
+        karpenter.sh/do-not-disrupt: "true"
     spec:
       serviceAccountName: backend-sa
       containers:


### PR DESCRIPTION
## Summary
- Adds \`karpenter.sh/do-not-disrupt: \"true\"\` to prod backend pods.
- Mirrors dev fix #51. After today's prod outage (2026-06-12) we know the same Karpenter consolidation pattern hits prod and can cascade into a CoreDNS-vs-EC2 deadlock when all stateless nodes get drained at once.
- Spot interruption (AWS-driven) is unaffected; only Karpenter's own consolidation/drift/expiration disruption is disabled.

## Why now
This morning Karpenter consolidated away every stateless node. CoreDNS doesn't tolerate the data-tier taint, so it went Pending → DNS down → Karpenter EC2 API DNS lookups failed → no new nodes could be provisioned → ~20 min full prod outage. Stopping voluntary disruption on the stateless tier removes the trigger.

## Test plan
- [ ] PR to \`develop\`, soak in \`chatbu-dev\` (annotation already shipped to dev)
- [ ] Promote \`develop\` → \`main\`, watch Karpenter logs in prod for the next 24h
- [ ] Verify no spontaneous backend pod evictions in prod