### PR TITLE
Promote develop → main: Karpenter do-not-disrupt (dev #51 + prod #52)

### DIFF
--- a/k8s-dev/patch-backend.yaml
+++ b/k8s-dev/patch-backend.yaml
@@ -16,6 +16,16 @@ metadata:
 spec:
   replicas: 1
   template:
+    metadata:
+      annotations:
+        # Stop Karpenter from draining the dev backend during consolidation.
+        # chatbu-dev pods land on the shared spot node group and have no PDB
+        # (single-replica dev), so Karpenter was free to evict them every
+        # 15-20 minutes, producing intermittent 503s at the ingress while
+        # the backend Service had no available endpoint. `do-not-disrupt`
+        # disables Karpenter consolidation for the pod. Spot interruption
+        # from AWS is unaffected (less frequent, unavoidable).
+        karpenter.sh/do-not-disrupt: "true"
     spec:
       containers:
         - name: backend

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -19,6 +19,15 @@ spec:
       labels:
         app: backend
         component: api
+      annotations:
+        # Karpenter consolidation was evicting prod backend pods during
+        # cluster-wide rebalancing — observed 2026-06-12 prod outage when
+        # all stateless pods were drained at once, the cluster ended up
+        # with zero Karpenter nodes, CoreDNS couldn't schedule, EC2 API
+        # DNS resolution broke for Karpenter, and a chicken-and-egg
+        # deadlock kept the cluster down ~20min. Voluntary disruption
+        # off; spot interruption (AWS-driven) is unaffected.
+        karpenter.sh/do-not-disrupt: "true"
     spec:
       serviceAccountName: backend-sa
       containers:


### PR DESCRIPTION
## Summary
Promote develop → main. Two commits behind main:
- #51 (dev) — \`karpenter.sh/do-not-disrupt\` on \`k8s-dev/patch-backend.yaml\`
- #52 (prod) — \`karpenter.sh/do-not-disrupt\` on \`k8s/deployment.yaml\` prod base

## Why now
Today's prod outage (2026-06-12, ~20min full 503) was triggered by Karpenter consolidating away every stateless prod node, which cascaded into a CoreDNS-vs-data-tier-taint deadlock. The CoreDNS half is already permanent via fovi-longa-chat-be#132 (terraform apply complete). This PR ships the other half: stop Karpenter voluntary disruption (consolidation/drift/expiration) on prod backend pods so the trigger doesn't fire in the first place.

Soak status:
- Dev annotation has been live in \`chatbu-dev\` since 2026-06-12 12:22 UTC, pods stable.
- Prod annotation merged to develop 2026-06-12 12:21 UTC; reconciled into \`chatbu-dev\` and stable.

Spot interruption (AWS-driven) is unaffected; only Karpenter's voluntary disruption is disabled.

## Test plan
- [ ] Merge → ArgoCD \`chatbu-backend\` (prod app) syncs the new annotation
- [ ] \`kubectl -n chatbu get deploy backend -o jsonpath='{.spec.template.metadata.annotations}'\` shows \`karpenter.sh/do-not-disrupt: true\`
- [ ] 24h soak: Karpenter logs show no \`disrupting via consolidation\` events for backend pods