### PR TITLE
fix(prod): enforce hard pod spread (DoNotSchedule) on prod backend

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -30,6 +30,25 @@ spec:
         karpenter.sh/do-not-disrupt: "true"
     spec:
       serviceAccountName: backend-sa
+      topologySpreadConstraints:
+        # Hard spread (DoNotSchedule) so a single node death or a
+        # single-AZ outage can't take backend fully down. Added
+        # 2026-06-12 after a prod outage where stateless pods packed
+        # onto a single node and one node-drain cascaded into a full
+        # tier outage. maxSkew=1 forces Karpenter to provision a new
+        # node rather than letting two replicas co-locate.
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              app: backend
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              app: backend
       containers:
       - name: backend
         image: 152100380489.dkr.ecr.eu-central-1.amazonaws.com/chatbu-repo:backend-latest


### PR DESCRIPTION
## Summary
Add \`topologySpreadConstraints\` to the prod backend pod template: \`maxSkew=1\`, \`DoNotSchedule\` on both \`topology.kubernetes.io/zone\` and \`kubernetes.io/hostname\`. Hard guarantee that no two backend replicas land on the same node or in the same AZ.

## Why now
2026-06-12 prod outage post-mortem: prod backend had **no scheduling constraints** at all. It happened to be on 2 different nodes / 2 different AZs by luck, not by design. \`mcp-server\` in the same outage actually had both replicas on the same node, confirming that without DoNotSchedule a tier can collapse into a single point of failure.

Combined with \`karpenter.sh/do-not-disrupt\` (PR #52, in prod) this closes the cluster-state side of the outage class for prod backend.

## Sister PRs
- fovi-longa-chat-be#134 — fastapi-gateway / ml-services / mcp-server
- chatbu-frontend (next) — prod frontend

## Test plan
- [ ] PR to develop → ArgoCD \`chatbu-backend-dev\` syncs (dev runs replicas=1 so no scheduling impact)
- [ ] Promote develop → main, ArgoCD prod app syncs
- [ ] \`kubectl -n chatbu get pods -l app=backend -o custom-columns=NODE:.spec.nodeName,ZONE:.metadata.labels.topology\\.kubernetes\\.io/zone\` shows 2 different nodes AND 2 different AZs
- [ ] HPA scale test (load): replicas go 2 → 6, each pod on a distinct node