### PR TITLE
Promote develop → main: hard pod spread on prod backend (DoNotSchedule)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,17 @@ Son 200 satır (takip etmeden): kubectl logs -n chatbu deploy/backend --tail=200
 Önceki crash logu (restart olduysa): kubectl logs -n chatbu deploy/backend --previous --tail=200
 Belirli poddan log al: kubectl logs -n chatbu <POD_ADI> --tail=200 -f
 Hata satırlarını filtrele: kubectl logs -n chatbu deploy/backend --tail=500 | egrep -i "error|exception|failed|timeout"
+
+## Postgres Port Forwarding
+# prod
+kubectl port-forward -n postgresql svc/chatbu-postgres-rw 5432:5432
+# dev
+kubectl port-forward -n chatbu-dev svc/chatbu-postgres-rw 5432:5432      
+
+
+
+Backenddeki envler çekme:
+# prod
+bash scripts/sync-k8s-env.sh chatbu backend-secrets
+# dev
+bash scripts/sync-k8s-env.sh chatbu-dev backend-secrets

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -30,6 +30,25 @@ spec:
         karpenter.sh/do-not-disrupt: "true"
     spec:
       serviceAccountName: backend-sa
+      topologySpreadConstraints:
+        # Hard spread (DoNotSchedule) so a single node death or a
+        # single-AZ outage can't take backend fully down. Added
+        # 2026-06-12 after a prod outage where stateless pods packed
+        # onto a single node and one node-drain cascaded into a full
+        # tier outage. maxSkew=1 forces Karpenter to provision a new
+        # node rather than letting two replicas co-locate.
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              app: backend
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              app: backend
       containers:
       - name: backend
         image: 152100380489.dkr.ecr.eu-central-1.amazonaws.com/chatbu-repo:backend-latest

--- a/src/subscription/subscription.service.ts
+++ b/src/subscription/subscription.service.ts
@@ -80,11 +80,14 @@ export class SubscriptionService {
 
             // Fetch upcoming invoice amount from Stripe
             try {
-                const upcomingInvoice = await this.stripe.invoices.createPreview({
-                    customer: subscription.stripeCustomerId,
-                });
-                nextBillingAmount = upcomingInvoice.amount_due / 100;
-                nextBillingCurrency = upcomingInvoice.currency;
+                if (subscription.stripeSubscriptionId) {
+                    const upcomingInvoice = await this.stripe.invoices.createPreview({
+                        customer: subscription.stripeCustomerId,
+                        subscription: subscription.stripeSubscriptionId,
+                    });
+                    nextBillingAmount = upcomingInvoice.amount_due / 100;
+                    nextBillingCurrency = upcomingInvoice.currency;
+                }
             } catch (error) {
                 // No upcoming invoice (e.g. no active Stripe subscription) — ignore
             }


### PR DESCRIPTION
## Summary
Promote develop → main. Commits behind main:
- #54 — \`topologySpreadConstraints\` (maxSkew=1, DoNotSchedule on zone + hostname) on prod backend pod template
- (and the upcoming-invoice subscription fix that landed on develop in parallel — unrelated, but rides along)

## Why now
Closes the cluster-state side of the 2026-06-12 outage for backend: pods can no longer co-locate on a single node or AZ, so a single node death tops out at 1 replica lost (PDB minAvailable=1 keeps the service up).

Dev (\`chatbu-backend-dev\`) has the change since merge to develop — replicas=1 there so no scheduling impact, but ArgoCD reconciled cleanly.

## Test plan
- [ ] Merge → ArgoCD \`chatbu-backend\` (prod) syncs
- [ ] \`kubectl -n chatbu get pods -l app=backend -o custom-columns=NODE:.spec.nodeName,ZONE:.metadata.labels.topology\\.kubernetes\\.io/zone\` shows 2 distinct nodes + 2 distinct AZs