### PR TITLE
fix(booking): add class-validator decorators so whitelist pipe stops stripping DTO fields

### DIFF
--- a/src/integration/booking/booking.controller.ts
+++ b/src/integration/booking/booking.controller.ts
@@ -9,23 +9,56 @@ import {
 } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
+import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
 import { InternalApiKeyGuard } from '../google-calendar/internal-api-key.guard';
 import { BookingService } from './booking.service';
 
+// main.ts registers a global ValidationPipe with `whitelist: true`. With
+// that flag any property NOT declared via class-validator decorators is
+// silently stripped from @Body() before the controller runs — so without
+// these decorators every booking call arrived with body={}, the controller
+// rejected it as "email and botCuid are required" (400), MCP mapped that
+// to BOOKING_TOOL_ARGUMENT_ERROR, and the bot told the user calendar was
+// down even though MCP, agent and Google Calendar were all fine. Observed
+// 2026-06-12 on Veri Bilimi Okulu dev with curl-from-MCP-pod repro.
 class RequestVerificationDto {
+    @IsString()
+    @IsNotEmpty()
+    @IsEmail()
     email!: string;
+
+    @IsString()
+    @IsNotEmpty()
     botCuid!: string;
 }
 
 class VerifyDto {
+    @IsString()
+    @IsNotEmpty()
+    @IsEmail()
     email!: string;
+
+    @IsString()
+    @IsNotEmpty()
     code!: string;
+
+    @IsString()
+    @IsNotEmpty()
     botCuid!: string;
 }
 
 class CheckTokenDto {
+    @IsString()
+    @IsNotEmpty()
     token!: string;
+
+    @IsString()
+    @IsNotEmpty()
+    @IsEmail()
     email!: string;
+
+    @IsString()
+    @IsNotEmpty()
     botCuid!: string;
 }
 


### PR DESCRIPTION
## Summary
Decorates the three booking DTOs (\`RequestVerificationDto\`, \`VerifyDto\`, \`CheckTokenDto\`) with \`@IsString\` / \`@IsNotEmpty\` / \`@IsEmail\`. Without them, the app-wide \`ValidationPipe({ whitelist: true })\` was silently stripping every field of every booking request, so every endpoint immediately threw \"email and botCuid are required\" (400).

## Why
2026-06-12 Veri Bilimi Okulu dev, real booking transcript:
> user: data engineering bootcamp kaç lira → bot: 37.400 TL ✓
> user: hangi günler ve tarihlerde → bot: 10 Eylül, 14 hafta, ... ✓
> user: yarın 14'e randevu ver bana → bot: 14:00'te yer açık, lütfen e-posta paylaşır mısınız ✓
> user: erkansirin78@hotmail.com → bot: \"Lütfen bir moment bekleyin...\"
> user: randevu ne oldu? → bot: \"Maalesef sistemde teknik bir sorun yaşıyorum...\"

Agent-side logs proved the tool calls were correct:
\`\`\`
'name': 'request_booking_verification',
'args': {'customer_cuid': 'cmq3xm3w300013uf03uyqmpe1',
         'bot_cuid':      'cmq3xsuh500053uf0krvd8d6r',
         'email':         'erkansirin78@hotmail.com'}
\`\`\`
MCP-side logs proved MCP forwarded the values to the backend correctly. But the backend kept returning \`{statusCode: 400, message: \"email and botCuid are required\"}\`.

A clean repro from inside the MCP pod (with the same X-Internal-Key header and the same JSON payload) returned the same 400. So the bug was 100% backend.

Root cause: \`main.ts\` runs
\`\`\`ts
app.useGlobalPipes(new ValidationPipe({ transform: true, whitelist: true }));
\`\`\`
\`whitelist: true\` strips any property that isn't explicitly declared via a \`class-validator\` decorator. The booking DTOs had ZERO decorators, so after the pipe, \`body\` became \`{}\`. The controller's existing guard \`if (!body.email || !body.botCuid)\` then rejected as 400 — a perfectly sensible defensive check that fired because the field upstream of it was eating its inputs.

## Fix
Decorators added on every property of the three DTOs:
- \`@IsString()\` + \`@IsNotEmpty()\` everywhere (so whitelist keeps the field and rejects null/empty)
- \`@IsEmail()\` on email fields (so the agent doesn't waste a verification flow on \"yarın 14:00\")

No behavior change for any other endpoint.

## Test plan
- [ ] Merge → \`chatbu-backend-dev\` rolls.
- [ ] Repro inside chatbu-dev mcp-server pod:
      \`curl -X POST -H \"Content-Type: application/json\" -H \"X-Internal-Key: \$MCP_INTERNAL_API_KEY\" -d '{\"email\":\"test@example.com\",\"botCuid\":\"cmq3xsuh500053uf0krvd8d6r\"}' \$BACKEND_INTEGRATION_URL/integration/booking/request-verification\`
      → should return 200 (and send a code), not 400.
- [ ] Re-run the booking transcript on Veri Bilimi Okulu dev:
  - randevu ver bana / yarın 14:00 → bot asks for email
  - email → bot confirms verification code sent to inbox
  - paste 6-digit code → bot calls create_appointment, calendar event appears in Google Calendar
- [ ] Promote develop → main after dev soak.

## Out of scope
- Other DTOs in the repo that already use class-validator decorators have always worked. The booking trio was the only one in this regression.