### PR TITLE
Promote develop → main: booking DTO decorators + price-plan/quota/subscription fixes

### DIFF
--- a/prisma/migrations/20260615113700_storage_kb_quota/migration.sql
+++ b/prisma/migrations/20260615113700_storage_kb_quota/migration.sql
@@ -1,0 +1,17 @@
+-- Migration: Switch FILE quota from count-based to KB-based storage quota
+-- Free users: 10 MB = 10240 KB
+-- Premium users: 250 MB = 256000 KB
+
+-- Reset all existing FILE quotas: limit = FREE default, used = 0
+-- Subscription-aware limits are applied by updateStorageQuotaLimits() on first request.
+UPDATE "Quota"
+SET "limit" = 10240,
+    "used"  = 0
+WHERE "quotaType" = 'FILE';
+
+-- Add SystemSettings entries for storage limits (skip if already exists)
+INSERT INTO "SystemSettings" ("id", "key", "value", "description", "createdAt", "updatedAt")
+VALUES
+  (left(md5(random()::text), 25), 'FREE_STORAGE_LIMIT_KB',    '10240',  'Free tier vector DB storage quota in KB (10 MB)',    NOW(), NOW()),
+  (left(md5(random()::text), 25), 'PREMIUM_STORAGE_LIMIT_KB', '256000', 'Premium tier vector DB storage quota in KB (250 MB)', NOW(), NOW())
+ON CONFLICT ("key") DO NOTHING;

--- a/src/content/content.service.ts
+++ b/src/content/content.service.ts
@@ -80,9 +80,10 @@ export class ContentService {
         // Quota check for URL-based content types
         if (isUrlBasedType && !existingUrlContent) {
             const quota = await this.getQuota(user.teamId);
-            if (quota.remaining < 1) {
+            if (quota.remainingKb <= 0) {
                 return {
-                    message: `Insufficient quota. You have used ${quota.used} of ${quota.limit} pages.`
+                    message: `Depolama kotanız doldu. ${quota.usedMb} MB / ${quota.limitMb} MB kullanıldı.`,
+                    quotaExceeded: true,
                 };
             }
         }
@@ -135,17 +136,7 @@ export class ContentService {
         if (isUrlBasedType) {
             console.log(`${body.type} content ingest started`);
             await this.ingestWebPage(body, user, body.content.url);
-
-            // Increment quota for URL-based types
-            const currentQuota = await this.prisma.quota.findFirst({
-                where: { teamId: user.teamId, quotaType: 'FILE' }
-            });
-            if (currentQuota) {
-                await this.prisma.quota.update({
-                    where: { id: currentQuota.id },
-                    data: { used: currentQuota.used + 1 }
-                });
-            }
+            // KB quota is updated by ML service after ingestion completes
         } else if (body.type === 'Q&A') {
             console.log("Q&A content ingest started");
             await this.ingestQA(body, user);
@@ -215,24 +206,7 @@ export class ContentService {
                 }
             })
 
-            // Decrease quota if content type is WEBPAGE
-            if (content && content.type === 'WEBPAGE') {
-                const currentQuota = await this.prisma.quota.findFirst({
-                    where: {
-                        teamId: user.teamId,
-                        quotaType: 'FILE'
-                    }
-                });
-
-                if (currentQuota && currentQuota.used > 0) {
-                    await this.prisma.quota.update({
-                        where: { id: currentQuota.id },
-                        data: { used: currentQuota.used - 1 }
-                    });
-                }
-            }
-
-            // Delete ingested vectors
+            // Delete ingested vectors (ML service will decrement quota via its own tracking)
             const data = await this.deleteIngestedContent(botId, user, sourceId);
 
             console.log("deleted Vectors response", data);
@@ -327,8 +301,6 @@ export class ContentService {
     }
 
     private async processDeleteAll(user: IUser, contents: any[], botId: string) {
-        let webpageCount = 0;
-
         for (const content of contents) {
             try {
                 // Determine sourceId based on content type
@@ -337,7 +309,6 @@ export class ContentService {
 
                 if (content.type === 'WEBPAGE' || content.type === 'VIDEO' || content.type === 'LINK') {
                     sourceId = contentData?.url || '';
-                    webpageCount++;
                 } else if (content.type === 'Q&A') {
                     sourceId = contentData?.meta?.source || '';
                 } else if (content.type === 'CONTENT') {
@@ -367,24 +338,7 @@ export class ContentService {
             }
         }
 
-        // Decrease quota for WEBPAGE type content
-        if (webpageCount > 0) {
-            const currentQuota = await this.prisma.quota.findFirst({
-                where: {
-                    teamId: user.teamId,
-                    quotaType: 'FILE'
-                }
-            });
-
-            if (currentQuota && currentQuota.used > 0) {
-                const newUsed = Math.max(0, currentQuota.used - webpageCount);
-                await this.prisma.quota.update({
-                    where: { id: currentQuota.id },
-                    data: { used: newUsed }
-                });
-            }
-        }
-
+        // KB quota is decremented by ML service when vectors are deleted
         console.log(`Bulk delete completed: ${contents.length} items processed`);
     }
 
@@ -591,12 +545,14 @@ export class ContentService {
                 };
             }
 
-            // Check quota
+            // Check quota — estimate ~300 KB per web page as a conservative guard
             const quota = await this.getQuota(user.teamId);
-            if (quota.remaining < newUrls.length) {
+            const estimatedKb = newUrls.length * 300;
+            if (quota.remainingKb < estimatedKb) {
                 return {
                     success: false,
-                    message: `Insufficient quota. You can add ${quota.remaining} more pages, but you're trying to add ${newUrls.length}.`
+                    quotaExceeded: true,
+                    message: `Depolama kotanız dolmak üzere. ${newUrls.length} sayfa için yaklaşık ${Math.round(estimatedKb / 1024 * 10) / 10} MB gerekiyor, kalan: ${quota.remainingMb} MB.`,
                 };
             }
 
@@ -654,17 +610,7 @@ export class ContentService {
                 }
             }
 
-            // Update quota after successful ingest + DB writes
-            const currentQuota = await this.prisma.quota.findFirst({
-                where: { teamId: user.teamId, quotaType: 'FILE' }
-            });
-
-            if (currentQuota) {
-                await this.prisma.quota.update({
-                    where: { id: currentQuota.id },
-                    data: { used: currentQuota.used + newUrls.length }
-                });
-            }
+            // KB quota is updated by ML service after ingestion completes (via pg_notify trigger)
 
             return {
                 success: true,
@@ -1139,65 +1085,31 @@ export class ContentService {
         try {
             const quotas = await this.quotaService.list(teamId);
             const fileQuota = quotas.find(q => q.quotaType === 'FILE');
-            const [activeDocuments, activeContents] = await Promise.all([
-                this.prisma.storage.count({
-                    where: {
-                        teamId,
-                        isDeleted: false,
-                    },
-                }),
-                this.prisma.content.findMany({
-                    where: {
-                        teamId,
-                        isDeleted: false,
-                    },
-                    select: {
-                        type: true,
-                        content: true,
-                    },
-                }),
-            ]);
-
-            // URL-based vault items are counted by distinct URL across WEBPAGE/LINK variants.
-            const urlTypeSet = new Set(['webpage', 'link']);
-            const distinctUrlSet = new Set<string>();
-            let nonUrlContentCount = 0;
-
-            for (const item of activeContents) {
-                const contentType = (item.type || '').toLowerCase();
-                if (urlTypeSet.has(contentType)) {
-                    const normalizedUrl = this.normalizeComparableUrl((item.content as any)?.url);
-                    if (normalizedUrl) {
-                        distinctUrlSet.add(normalizedUrl);
-                        continue;
-                    }
-                }
-                nonUrlContentCount += 1;
-            }
-
-            const used = activeDocuments + nonUrlContentCount + distinctUrlSet.size;
 
             if (!fileQuota) {
                 return {
-                    limit: 0,
-                    used,
-                    remaining: 0
+                    limitKb: 0, usedKb: 0, remainingKb: 0,
+                    limitMb: 0, usedMb: 0, remainingMb: 0,
                 };
             }
 
-            const remaining = Math.max(fileQuota.limit - used, 0);
+            const usedKb = fileQuota.used;
+            const limitKb = fileQuota.limit;
+            const remainingKb = Math.max(limitKb - usedKb, 0);
 
             return {
-                limit: fileQuota.limit,
-                used,
-                remaining
+                limitKb,
+                usedKb,
+                remainingKb,
+                limitMb: Math.round((limitKb / 1024) * 100) / 100,
+                usedMb: Math.round((usedKb / 1024) * 100) / 100,
+                remainingMb: Math.round((remainingKb / 1024) * 100) / 100,
             };
         } catch (error) {
             console.error('Error fetching quota:', error);
             return {
-                limit: 0,
-                used: 0,
-                remaining: 0
+                limitKb: 0, usedKb: 0, remainingKb: 0,
+                limitMb: 0, usedMb: 0, remainingMb: 0,
             };
         }
     }

--- a/src/file/file.service.ts
+++ b/src/file/file.service.ts
@@ -64,15 +64,21 @@ export class FileService {
                 }
             }
 
-            if (existingQuota.Quota[0].used + files.length > existingQuota.Quota[0].limit) {
+            // KB-based quota check
+            const totalUploadKb = files.reduce((sum, f) => sum + Math.ceil(f.size / 1024), 0);
+            if (existingQuota.Quota[0].used + totalUploadKb > existingQuota.Quota[0].limit) {
+                const limitMb = (existingQuota.Quota[0].limit / 1024).toFixed(1);
+                const usedMb = (existingQuota.Quota[0].used / 1024).toFixed(1);
+                const remainingKb = Math.max(existingQuota.Quota[0].limit - existingQuota.Quota[0].used, 0);
                 return {
-                    message: "Quota exceeded",
-                    limit: existingQuota.Quota[0].limit,
-                    used: existingQuota.Quota[0].used,
-                    remaining: existingQuota.Quota[0].limit - existingQuota.Quota[0].used
+                    message: `Depolama kotanız doldu. ${usedMb} MB / ${limitMb} MB kullanıldı.`,
+                    quotaExceeded: true,
+                    limitKb: existingQuota.Quota[0].limit,
+                    usedKb: existingQuota.Quota[0].used,
+                    remainingKb,
                 }
             }
-            console.log("filesLength", files.length, " used..:", existingQuota.Quota[0].used)
+            console.log("filesLength", files.length, " totalUploadKb:", totalUploadKb, " used..:", existingQuota.Quota[0].used)
             //async function to upload files
             for (const file of files) {
                 const uploaded_file = await this.minioClientService.upload(file, this.configService.get('S3_BUCKET_NAME'), user.teamId, body.botId)
@@ -121,7 +127,7 @@ export class FileService {
                                 }
                             },
                             data: {
-                                used: (existingQuota.Quota[0].used + files.length)
+                                used: existingQuota.Quota[0].used + totalUploadKb
                             }
                         }
                     }
@@ -221,6 +227,8 @@ export class FileService {
 
                     console.log("existingQuota", existingQuota);
 
+                    // KB-based quota decrease on single file delete
+                    const fileKb = Math.ceil(parseInt(file.size || '0') / 1024);
                     const decreaseQuota = await this.prisma.team.update({
                         where: {
                             id: user.teamId,
@@ -240,7 +248,7 @@ export class FileService {
                                         }
                                     },
                                     data: {
-                                        used: existingQuota.Quota[0].used - 1
+                                        used: Math.max(0, existingQuota.Quota[0].used - fileKb)
                                     }
                                 }
                             }
@@ -379,8 +387,9 @@ export class FileService {
             }
         }
 
-        // Decrease quota
+        // KB-based quota decrease on bulk file delete
         if (deletedCount > 0) {
+            const totalDeletedKb = files.reduce((sum, f) => sum + Math.ceil(parseInt(f.size || '0') / 1024), 0);
             const existingQuota = await this.prisma.team.findFirst({
                 where: {
                     id: user.teamId,
@@ -392,7 +401,7 @@ export class FileService {
             });
 
             if (existingQuota?.Quota?.[0]) {
-                const newUsed = Math.max(0, existingQuota.Quota[0].used - deletedCount);
+                const newUsed = Math.max(0, existingQuota.Quota[0].used - totalDeletedKb);
                 await this.prisma.quota.update({
                     where: {
                         teamId_quotaType: {

--- a/src/integration/booking/booking.controller.ts
+++ b/src/integration/booking/booking.controller.ts
@@ -9,23 +9,56 @@ import {
 } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { Throttle } from '@nestjs/throttler';
+import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
 import { InternalApiKeyGuard } from '../google-calendar/internal-api-key.guard';
 import { BookingService } from './booking.service';
 
+// main.ts registers a global ValidationPipe with `whitelist: true`. With
+// that flag any property NOT declared via class-validator decorators is
+// silently stripped from @Body() before the controller runs — so without
+// these decorators every booking call arrived with body={}, the controller
+// rejected it as "email and botCuid are required" (400), MCP mapped that
+// to BOOKING_TOOL_ARGUMENT_ERROR, and the bot told the user calendar was
+// down even though MCP, agent and Google Calendar were all fine. Observed
+// 2026-06-12 on Veri Bilimi Okulu dev with curl-from-MCP-pod repro.
 class RequestVerificationDto {
+    @IsString()
+    @IsNotEmpty()
+    @IsEmail()
     email!: string;
+
+    @IsString()
+    @IsNotEmpty()
     botCuid!: string;
 }
 
 class VerifyDto {
+    @IsString()
+    @IsNotEmpty()
+    @IsEmail()
     email!: string;
+
+    @IsString()
+    @IsNotEmpty()
     code!: string;
+
+    @IsString()
+    @IsNotEmpty()
     botCuid!: string;
 }
 
 class CheckTokenDto {
+    @IsString()
+    @IsNotEmpty()
     token!: string;
+
+    @IsString()
+    @IsNotEmpty()
+    @IsEmail()
     email!: string;
+
+    @IsString()
+    @IsNotEmpty()
     botCuid!: string;
 }
 

--- a/src/quota/quota.service.ts
+++ b/src/quota/quota.service.ts
@@ -56,7 +56,9 @@ export class QuotaService {
                     }
                 },
                 quotaType: 'FILE',
-                limit: 100,
+                limit: isFree
+                    ? parseInt(await this.getSettingValue('FREE_STORAGE_LIMIT_KB', '10240'))
+                    : parseInt(await this.getSettingValue('PREMIUM_STORAGE_LIMIT_KB', '256000')),
                 used: 0
             }
         });
@@ -120,6 +122,82 @@ export class QuotaService {
                 });
             }
         }
+    }
+
+    async updateStorageQuotaLimits(userId: string) {
+        // Update FILE quota limits when user upgrades/downgrades (KB-based)
+        const subscription = await this.prisma.subscription.findUnique({
+            where: { userId },
+        });
+
+        const teams = await this.prisma.team.findMany({
+            where: { ownerId: userId },
+        });
+
+        const isFree = !subscription || subscription.tier === 'FREE';
+        const freeLimit = parseInt(await this.getSettingValue('FREE_STORAGE_LIMIT_KB', '10240'));
+        const premiumLimit = parseInt(await this.getSettingValue('PREMIUM_STORAGE_LIMIT_KB', '256000'));
+        const storageLimit = isFree ? freeLimit : premiumLimit;
+
+        for (const team of teams) {
+            const quota = await this.prisma.quota.findFirst({
+                where: { teamId: team.id, quotaType: 'FILE' },
+            });
+            if (quota) {
+                await this.prisma.quota.update({
+                    where: { id: quota.id },
+                    data: { limit: storageLimit },
+                });
+            }
+        }
+    }
+
+    async addStorageUsageKb(teamId: string, additionalKb: number): Promise<void> {
+        // Atomically increment FILE quota used by additionalKb.
+        // Called by ML service callback after ingestion completes.
+        const quota = await this.prisma.quota.findFirst({
+            where: { teamId, quotaType: 'FILE' },
+        });
+        if (quota) {
+            await this.prisma.quota.update({
+                where: { id: quota.id },
+                data: { used: Math.max(0, quota.used + additionalKb) },
+            });
+        }
+    }
+
+    async subtractStorageUsageKb(teamId: string, kbToRemove: number): Promise<void> {
+        // Decrement FILE quota used when content is deleted.
+        const quota = await this.prisma.quota.findFirst({
+            where: { teamId, quotaType: 'FILE' },
+        });
+        if (quota) {
+            await this.prisma.quota.update({
+                where: { id: quota.id },
+                data: { used: Math.max(0, quota.used - kbToRemove) },
+            });
+        }
+    }
+
+    async checkStorageQuota(teamId: string, estimatedKb: number): Promise<{
+        allowed: boolean;
+        usedKb: number;
+        limitKb: number;
+        remainingKb: number;
+    }> {
+        const quota = await this.prisma.quota.findFirst({
+            where: { teamId, quotaType: 'FILE' },
+        });
+        if (!quota) {
+            return { allowed: false, usedKb: 0, limitKb: 0, remainingKb: 0 };
+        }
+        const remainingKb = Math.max(quota.limit - quota.used, 0);
+        return {
+            allowed: quota.used + estimatedKb <= quota.limit,
+            usedKb: quota.used,
+            limitKb: quota.limit,
+            remainingKb,
+        };
     }
 
     private async getSettingValue(key: string, defaultValue: string): Promise<string> {

--- a/src/subscription/dto/price-plan.dto.ts
+++ b/src/subscription/dto/price-plan.dto.ts
@@ -1,9 +1,20 @@
+import { IsNumber, IsPositive, IsString } from 'class-validator';
+
 export class CreatePricePlanDto {
+    @IsNumber()
+    @IsPositive()
     monthlyBaseUsd: number;
+
+    @IsNumber()
+    @IsPositive()
     yearlyBaseUsd: number;
+
+    @IsNumber()
+    @IsPositive()
     tokenPer1000Usd: number;
 }
 
 export class PublishPricePlanDto {
+    @IsString()
     confirmationText: string; // "CONFIRM" gelmeli
 }

--- a/src/subscription/subscription.service.ts
+++ b/src/subscription/subscription.service.ts
@@ -81,12 +81,15 @@ export class SubscriptionService {
             // Fetch upcoming invoice amount from Stripe
             try {
                 if (subscription.stripeSubscriptionId) {
-                    const upcomingInvoice = await this.stripe.invoices.createPreview({
-                        customer: subscription.stripeCustomerId,
-                        subscription: subscription.stripeSubscriptionId,
-                    });
-                    nextBillingAmount = upcomingInvoice.amount_due / 100;
-                    nextBillingCurrency = upcomingInvoice.currency;
+                    const stripeSub = await this.stripe.subscriptions.retrieve(subscription.stripeSubscriptionId);
+                    if (stripeSub.status !== 'canceled') {
+                        const upcomingInvoice = await this.stripe.invoices.createPreview({
+                            customer: subscription.stripeCustomerId,
+                            subscription: subscription.stripeSubscriptionId,
+                        });
+                        nextBillingAmount = upcomingInvoice.amount_due / 100;
+                        nextBillingCurrency = upcomingInvoice.currency;
+                    }
                 }
             } catch (error) {
                 // No upcoming invoice (e.g. no active Stripe subscription) — ignore


### PR DESCRIPTION
## Summary
Promote develop → main. Commits behind main:
- #56 (today) — \`fix(booking)\`: class-validator decorators on RequestVerificationDto / VerifyDto / CheckTokenDto so the global \`whitelist: true\` ValidationPipe stops stripping the fields. End-to-end booking on Veri Bilimi Okulu dev confirmed working after this.
- \`feat(price-plan)\`: validation decorators on CreatePricePlanDto and PublishPricePlanDto.
- \`feat(quota)\`: switch FILE quota from count-based to KB-based storage limits.
- \`fix(subscription)\`: upcoming invoice fetched only for active subscriptions.

## Why now
After today's dev soak the booking + supporting fixes are all stable. Veri Bilimi Okulu test bot ran the full flow (\"randevu istiyorum → yarın 15:00 → mlops → email → 6-digit code → calendar invitation arrives\") successfully end-to-end.

## Test plan
- [ ] Merge → ArgoCD \`chatbu-backend\` (prod) syncs.
- [ ] Prod curl repro from MCP pod:
  \`POST /api/integration/booking/request-verification\` with valid \`X-Internal-Key\` + JSON body \`{email, botCuid}\` → 200, not 400.
- [ ] 24h soak: prod price-plan / quota / subscription endpoints unchanged behavior.