### PR TITLE
fix(topology): hostname spread maxSkew 1→2 (prep for 3-node baseline)

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -43,7 +43,7 @@ spec:
           labelSelector:
             matchLabels:
               app: backend
-        - maxSkew: 1
+        - maxSkew: 2
           topologyKey: kubernetes.io/hostname
           whenUnsatisfiable: DoNotSchedule
           labelSelector:


### PR DESCRIPTION
## Summary
Relax hostname-axis \`topologySpreadConstraints\` from \`maxSkew=1\` to \`maxSkew=2\` on prod backend Deployment. Zone-axis spread (\`maxSkew=1 DoNotSchedule\`) untouched.

Step 3 of \`/home/train/.claude/plans/this-is-a-example-ticklish-dove.md\`. Sister PRs are open in \`fovi-longa-chat-be\` and \`chatbu-frontend\`.

## Why
Strict hostname spread (\`maxSkew=1\`) demands 6 distinct nodes when HPA scales backend to 6, blocking the upcoming move to a fixed 3-node on-demand baseline. \`maxSkew=2\` lets peak HPA pack onto 3 nodes (2/2/2) without losing the scheduler's preference for spread when slots exist.

## Test plan
- [ ] PR to \`develop\`, ArgoCD \`chatbu-backend-dev\` syncs (dev replicas=1, no scheduling impact)
- [ ] Promote develop → main, ArgoCD prod backend syncs
- [ ] Existing 5-node stateless tier shows no visible change today