### PR TITLE
Promote develop → main: hostname spread maxSkew 1→2 (prep for 3-node baseline)

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -43,7 +43,7 @@ spec:
           labelSelector:
             matchLabels:
               app: backend
-        - maxSkew: 1
+        - maxSkew: 2
           topologyKey: kubernetes.io/hostname
           whenUnsatisfiable: DoNotSchedule
           labelSelector:


### PR DESCRIPTION
## Summary
Promote develop → main. One commit:
- #63 — relax \`hostname\` topologySpread to \`maxSkew=2\` on prod backend Deployment.

Sister PRs landing on \`main\` in parallel:
- fovi-longa-chat-be → main-services + ML
- chatbu-frontend → frontend

## Why now
Wave 1 of the spot → on-demand baseline plan. Prereq for the Wave 2 shrink to 3 fixed nodes.

## Test plan
- [ ] Merge → ArgoCD \`chatbu-backend\` (prod) syncs.
- [ ] \`kubectl -n chatbu get pods -l app=backend\` distribution unchanged today.