### PR TITLE
fix(hpa): cap backend maxReplicas at 4 (was 6) — Wave 2 prep

### DIFF
--- a/k8s/hpa.yaml
+++ b/k8s/hpa.yaml
@@ -9,7 +9,7 @@ spec:
     kind: Deployment
     name: backend
   minReplicas: 2
-  maxReplicas: 6
+  maxReplicas: 4
   metrics:
     - type: Resource
       resource:


### PR DESCRIPTION
## Summary
Lower the HPA \`maxReplicas\` on \`backend\` from 6 to 4 in \`k8s/hpa.yaml\`. Sister PR opens against \`fovi-longa-chat-be\` for fastapi-gateway + ml-services.

## Why
Wave 2 of the plan in \`/home/train/.claude/plans/this-is-a-example-ticklish-dove.md\`. Stateless tier migrates from Karpenter-managed spot to fixed 2 × c6a.2xlarge on-demand. With Karpenter gone, peak HPA must fit on 2 nodes — and remain schedulable when one is lost.

Backend max=4 → peak 1.2 vCPU / 2.0 GiB; total tier peak (all services at max) 5.0 vCPU / 9.0 GiB; 2 × c6a.2xlarge allocatable ≈ 14 vCPU / 28 GiB → bol marj, demo güvenli.

## Test plan
- [ ] PR to \`develop\`, ArgoCD \`chatbu-backend-dev\` syncs (dev replicas=1, no scheduling impact)
- [ ] \`kubectl -n chatbu-dev get hpa backend\` shows \`MAXPODS=4\`
- [ ] Promote develop → main, ArgoCD prod backend syncs
- [ ] Wave 2 Step 1 (terraform) lands afterwards and peak backend HPA fits cleanly on the 2-node baseline