### PR TITLE
fix(topology): relax backend zone spread maxSkew 1→2 (unblocks stuck rollouts on 2-AZ stateless tier)

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -37,7 +37,7 @@ spec:
         # onto a single node and one node-drain cascaded into a full
         # tier outage. maxSkew=1 forces Karpenter to provision a new
         # node rather than letting two replicas co-locate.
-        - maxSkew: 1
+        - maxSkew: 2
           topologyKey: topology.kubernetes.io/zone
           whenUnsatisfiable: DoNotSchedule
           labelSelector:


### PR DESCRIPTION
## Summary
Relax backend's \`topology.kubernetes.io/zone\` spread from \`maxSkew=1\` to \`maxSkew=2\`. Hostname-axis (\`maxSkew=2\`, DoNotSchedule) untouched.

## Why now
Wave 2 retired the spot tier down to **2 on-demand c6a.2xlarge nodes** in **eu-central-1a + 1b** (1c has no stateless node — only data-tier, which is taint-gated). With zone \`maxSkew=1 DoNotSchedule\` and 2 existing backend pods (1a:1, 1b:1, 1c:0), any 3rd pod — whether from rollout surge or HPA scale-up — hits skew=2 and stays Pending. Observed today after PR #67 triggered a rollout: 1 pod stuck Pending for >2h, CI \`kubectl rollout status\` timed out (run 27773111445).

Wave 1 (#63) relaxed hostname-axis from 1→2 to fit peak HPA on the 3-node baseline. The zone axis needed the same treatment for the 2-node baseline we ended up shipping — I missed it in the plan.

## Effect
- Unblocks the stuck \`backend-76d76bb86\` ReplicaSet — the new replica schedules onto 1a or 1b, zone skew becomes 2 (within limit).
- Future HPA scale-ups schedule cleanly (1a:2 + 1b:2 → skew=0).
- AZ outage now loses up to 2 replicas (vs 1 before) — but with only 2 AZs hosting stateless capacity, that was already the realistic worst case.

## Sister PR
A follow-up will land in \`fovi-longa-chat-be\` for fastapi-gateway / ml-services / mcp-server. Same gap.

## Test plan
- [ ] Merge → ArgoCD \`chatbu-backend-dev\` syncs
- [ ] Promote develop → main, ArgoCD \`chatbu-backend\` syncs
- [ ] Pending pod \`backend-76d76bb86-qkjsh\` clears
- [ ] CI re-run on #67 merge commit succeeds