### PR TITLE
Promote develop → main: backend zone maxSkew 1→2 (unblock stuck rollout)

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -37,7 +37,7 @@ spec:
         # onto a single node and one node-drain cascaded into a full
         # tier outage. maxSkew=1 forces Karpenter to provision a new
         # node rather than letting two replicas co-locate.
-        - maxSkew: 1
+        - maxSkew: 2
           topologyKey: topology.kubernetes.io/zone
           whenUnsatisfiable: DoNotSchedule
           labelSelector:


### PR DESCRIPTION
## Summary
Promote develop → main. Commit:
- #68 — \`topology.kubernetes.io/zone\` spread relax \`maxSkew: 1 → 2\` on prod backend pod template.

Sister PRs landing on \`main\` in parallel:
- \`chatbu-frontend\` → frontend zone spread.
- \`fovi-longa-chat-be\` → fastapi-gateway / ml-services / mcp-server zone spread.

## Why now
Right after merging this, ArgoCD \`chatbu-backend\` will sync the relaxed constraint, and the Pending \`backend-76d76bb86-qkjsh\` pod (waiting since the #67 rollout) will schedule onto 1a or 1b. That clears the stuck rollout and the failed CI run (27773111445) can be re-run successfully.

## Test plan
- [ ] Merge → ArgoCD prod \`chatbu-backend\` syncs
- [ ] \`kubectl -n chatbu get pods -l app=backend\` shows no Pending
- [ ] Re-run failed CI for #67 commit \`6c184cb\` — \`gh -R makeanewgame/chatbu-backend run rerun 27773111445\` → expected success now